### PR TITLE
In SpinalRelationConstructor: ids added to children.info using add_attr

### DIFF
--- a/src/Relations/SpinalRelationPtrLst.js
+++ b/src/Relations/SpinalRelationPtrLst.js
@@ -12,7 +12,7 @@ class SpinalRelationPtrLst extends BaseSpinalRelation {
             children: new SpinalNodePointer(new globalType.Lst())
         })
 
-        this.children.info.ids = [];
+        this.children.info.add_attr("ids", []);
     }
 
 
@@ -37,7 +37,7 @@ class SpinalRelationPtrLst extends BaseSpinalRelation {
      * @param node {SpinalNode | globalType.Model}
      */
     addChild(node) {
-        if (node instanceof SpinalNode && !this.children.info.ids.includes(node.getId())) {
+        if (node instanceof SpinalNode && !this.children.info.ids.contains(node.getId())) {
             this.children.info.ids.push(node.getId());
             promiseLoad(this.children).then((children) => {
                 children.push(node);


### PR DESCRIPTION
The attribute "ids" was added to children.info without using add_attr which means it wasn't stored.
Because of the use add_attr ids became a Lst, because of that the function addChild was changed (the equivalent of includes for an Array is contains for a Lst).